### PR TITLE
fix: 修复 #31 合并导致的构建失败

### DIFF
--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -203,20 +203,16 @@ func TestSession_ForceTerminate(t *testing.T) {
 
 	command, args := testSleepCommand("60")
 	s, err := New(srv, testConfig(command, args, api.ModePipe, ""), nil)
-
-	s, err := New(srv, testConfig(testShell(), testInteractiveShellArgs(), api.ModePTY, ""), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Terminate(true, 0)
 
-	if err := s.ResizePty(50, 120); err != nil {
-		t.Fatalf("ResizePty failed: %v", err)
-	}
+	s.Terminate(true, 0)
 
+	time.Sleep(200 * time.Millisecond)
 	info := s.Info()
-	if info.Rows != 50 || info.Cols != 120 {
-		t.Fatalf("expected 50x120, got %dx%d", info.Rows, info.Cols)
+	if info.Status != api.SessionExited {
+		t.Fatalf("expected 'exited' after force terminate, got %q", info.Status)
 	}
 }
 

--- a/internal/sshserver/server.go
+++ b/internal/sshserver/server.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/ssh"
+	"github.com/pkg/sftp"
 	sshstd "golang.org/x/crypto/ssh"
 )
 


### PR DESCRIPTION
- internal/sshserver/server.go: 补回丢失的 "github.com/pkg/sftp" 导入， 否则 sftp.NewServer 未定义，go build 直接失败。
- internal/session/session_test.go: TestSession_ForceTerminate 还原为 bed3fc7 版本；#31 合并引入了重复 := 声明、泄漏的首个 New 以及错位的 ResizePty 断言，导致测试无法编译。